### PR TITLE
Prepare for 64-bit SMAPI

### DIFF
--- a/BiggerBackpack.csproj
+++ b/BiggerBackpack.csproj
@@ -20,21 +20,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\StardewHack\StardewHack.csproj">
-      <Private>false</Private>
-    </ProjectReference>
+    <ProjectReference Include="..\StardewHack\StardewHack.csproj" Private="false" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="README.md">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="backpack.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="JunimoNote.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <None Update="README.md" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="backpack.png" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="JunimoNote.png" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/BiggerBackpack.csproj
+++ b/BiggerBackpack.csproj
@@ -5,15 +5,13 @@
     <RootNamespace>BiggerBackpack</RootNamespace>
     <Version>1.6.0</Version>
     <TargetFramework>net452</TargetFramework>
-    <Platforms>x86</Platforms>
-    <PlatformTarget>x86</PlatformTarget>
 
     <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
 
   <!-- required for MonoDevelop compatibility -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' " />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|Any CPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|Any CPU' " />
 
   <ItemGroup>
     <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.2.2" />


### PR DESCRIPTION
This prepares Bigger Backpack for the upcoming [64-bit SMAPI](https://stardewvalleywiki.com/Modding:Migrate_to_64-bit_on_Windows). It'll still work fine in 32-bit mode with this change.

This only changes the project itself. I also get a few _could not find instruction sequence_ errors ([see sample log](https://smapi.io/log/9599bbbe7c4541bfaa10ef86932183a7)) that aren't covered by this PR. If you're interested, [#making-mods on Discord](https://smapi.io/community#Discord) has pinned instructions to try 64-bit mode.